### PR TITLE
Fix UnicodeDecodeError in the code HDT.py

### DIFF
--- a/Source Code/HDT.py
+++ b/Source Code/HDT.py
@@ -29,7 +29,9 @@ articleTitle = list() # Lists to hold article id wise title name and pv
 articlepv = list()
 sum_pv = 0
 ID = 0
-in_file = open("HDTdata4.txt", "r")
+in_file = open("HDTdata4.txt", "r", encoding="latin-1")  # Specify the correct encoding
+
+
 
 for line in in_file:
     if ID == 0: # excluding first line as it is header


### PR DESCRIPTION
The following error message is returned with the current code (line 34).

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xac in position 6693: invalid start byte

The code was updated with the encoding below:

in_file = open("HDTdata4.txt", "r", encoding="latin-1")